### PR TITLE
Use id instead of group name for lessons api call

### DIFF
--- a/app/app.component.html
+++ b/app/app.component.html
@@ -4,7 +4,7 @@
     <label for="groupName">Group name: </label>
     <input class="form-control" [(ngModel)]="groupName" name="groupName" type="text" list="groupNamesList">
     <datalist id="groupNamesList">
-      <option *ngFor="#groupName of groupNames" [value]="groupName">
+      <option *ngFor="#groupName of objectKeys(groups)" [value]="groupName">
     </datalist>
     <label for="calendarName">Calendar name: </label>
     <input class="form-control" [(ngModel)]="calendarName" name="calendarName" type="text">


### PR DESCRIPTION
This solves the problem of not being able to export some groups as those have the same name.
Now, group id is used instead of name for api calls.
If two groups have the same name then group id is also shown in the list.